### PR TITLE
[E3DB-974] Changed cipher init to work w GCM params when Android KeyS…

### DIFF
--- a/androidtest/build.gradle
+++ b/androidtest/build.gradle
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId "com.tozny.e3dbtest"
-        minSdkVersion 19
+        minSdkVersion 16
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"

--- a/e3db-crypto-android/build.gradle
+++ b/e3db-crypto-android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 26
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 16
         targetSdkVersion 19
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
…tore key and IV params when not, using reflection. Got rid of magic 128 number.